### PR TITLE
chore: drop redundant js-yaml and brace-expansion overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,9 +86,6 @@
   },
   "pnpm": {
     "overrides": {
-      "brace-expansion@<1.1.17": "1.1.17",
-      "brace-expansion@>=4.0.0 <5.0.8": "5.0.8",
-      "js-yaml": "^4.3.0",
       "postcss": "^8.5.18",
       "sharp": "^0.35.0"
     }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,6 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.17: 1.1.17
-  brace-expansion@>=4.0.0 <5.0.8: 5.0.8
-  js-yaml: ^4.3.0
   postcss: ^8.5.18
   sharp: ^0.35.0
 


### PR DESCRIPTION
## Summary
Follow-up audit after #19 merged. Re-checked the dependency tree with the overrides removed:

- `js-yaml` and `brace-expansion` now resolve to patched versions naturally (`js-yaml@4.3.1`, `brace-expansion@1.1.17`/`5.0.8`) without needing an explicit override — eslint/@typescript-eslint's own dependency ranges already pick these up.
- `postcss` and `sharp` overrides are kept, since Next.js still pins older vulnerable versions of both internally.

## Verification
- `pnpm audit`: 0 vulnerabilities
- `pnpm lint`: pass
- `pnpm build`: pass (static export to `out/`)

Co-Authored-By: Oz <oz-agent@warp.dev>